### PR TITLE
 feat(std): add std feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ documentation = "https://docs.rs/static-regular-grammar"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 
+[features]
+std = []
+
 [lib]
 proc-macro = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [features]
+default = ["std"]
 std = []
 
 [lib]

--- a/src/byteset.rs
+++ b/src/byteset.rs
@@ -172,7 +172,7 @@ impl fmt::Display for ByteSet {
 
 impl fmt::Debug for ByteSet {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "CharSet({})", self)
+		write!(f, "CharSet({self})")
 	}
 }
 

--- a/src/charset.rs
+++ b/src/charset.rs
@@ -19,11 +19,11 @@ impl fmt::Display for DisplayChar {
 			_ if c.is_control() => {
 				let d = c as u32;
 				if d <= 0xff {
-					write!(f, "\\x{:02x}", d)
+					write!(f, "\\x{d:02x}")
 				} else if d <= 0xffff {
-					write!(f, "\\u{:04x}", d)
+					write!(f, "\\u{d:04x}")
 				} else {
-					write!(f, "\\U{:08x}", d)
+					write!(f, "\\U{d:08x}")
 				}
 			}
 			_ => c.fmt(f),
@@ -184,7 +184,7 @@ impl fmt::Display for CharSet {
 
 impl fmt::Debug for CharSet {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "CharSet({})", self)
+		write!(f, "CharSet({self})")
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,14 +407,26 @@ fn generate_typed<T: Token>(
 
 	let error = format_ident!("Invalid{}", ident);
 	let error_msg = format!("Invalid {name} `{{0}}`");
+	let lib_string: syn::Path = syn::parse_str(if cfg!(feature = "std") {
+		"::std::string::String"
+	} else {
+		"::alloc::string::String"
+	})
+	.expect("unexpected string::String path parsing error");
+	let to_owned: syn::Path = syn::parse_str(if cfg!(feature = "std") {
+		"::std::borrow::ToOwned"
+	} else {
+		"::alloc::borrow::ToOwned"
+	})
+	.expect("unexpected borrow::ToOwned path parsing error");
 
 	let new_doc = format!("Creates a new {name} by parsing the `input` value");
 	let new_unchecked_doc = formatdoc!(
 		r#"
         Creates a new {name} from the `input` value without validation.
-        
+
         # Safety
-        
+
         The input data *must* be a valid {name}."#
 	);
 
@@ -437,7 +449,7 @@ fn generate_typed<T: Token>(
 			}
 		}
 
-		impl<T: ::core::fmt::Debug + ::core::fmt::Display> ::std::error::Error for #error<T> {}
+		impl<T: ::core::fmt::Debug + ::core::fmt::Display> ::core::error::Error for #error<T> {}
 
 		impl #ident {
 			#[doc = #new_doc]
@@ -624,7 +636,7 @@ fn generate_typed<T: Token>(
 
 		let visit_bytes = if T::UNICODE {
 			quote! {
-				match std::str::from_utf8(v) {
+				match core::str::from_utf8(v) {
 					Ok(s) => #ident::new(s).map_err(|_| ()),
 					Err(e) => Err(())
 				}
@@ -691,9 +703,9 @@ fn generate_typed<T: Token>(
 		let owned_new_unchecked_doc = formatdoc!(
 			r#"
 			Creates a new owned {name} from the `input` value without validation.
-			
+
 			# Safety
-			
+
 			The input data *must* be a valid {name}."#
 		);
 
@@ -744,7 +756,7 @@ fn generate_typed<T: Token>(
 				}
 			}
 
-			impl ::std::borrow::ToOwned for #ident {
+			impl #to_owned for #ident {
 				type Owned = #buffer_ident;
 
 				fn to_owned(&self) -> #buffer_ident {
@@ -774,20 +786,20 @@ fn generate_typed<T: Token>(
 		if !T::UNICODE && ascii {
 			tokens.extend(quote! {
 				impl #buffer_ident {
-					pub fn into_string(self) -> ::std::string::String {
+					pub fn into_string(self) -> #lib_string {
 						unsafe {
-							::std::string::String::from_utf8_unchecked(self.0)
+							#lib_string::from_utf8_unchecked(self.0)
 						}
 					}
 				}
 
-				impl TryFrom<::std::string::String> for #buffer_ident {
-					type Error = #error<::std::string::String>;
+				impl TryFrom<#lib_string> for #buffer_ident {
+					type Error = #error<#lib_string>;
 
-					fn try_from(input: ::std::string::String) -> Result<#buffer_ident, #error<::std::string::String>> {
+					fn try_from(input: #lib_string) -> Result<#buffer_ident, #error<#lib_string>> {
 						let bytes = input.into_bytes();
 						#buffer_ident::new(bytes).map_err(|#error(bytes)| unsafe {
-							#error(::std::string::String::from_utf8_unchecked(bytes))
+							#error(#lib_string::from_utf8_unchecked(bytes))
 						})
 					}
 				}
@@ -802,10 +814,10 @@ fn generate_typed<T: Token>(
 
 		if T::UNICODE || ascii {
 			tokens.extend(quote! {
-				impl ::std::str::FromStr for #buffer_ident {
-					type Err = #error<::std::string::String>;
+				impl ::core::str::FromStr for #buffer_ident {
+					type Err = #error<#lib_string>;
 
-					fn from_str(s: &str) -> Result<Self, #error<::std::string::String>> {
+					fn from_str(s: &str) -> Result<Self, #error<#lib_string>> {
 						let buffer = s.to_string();
 						buffer.try_into()
 					}
@@ -1010,7 +1022,7 @@ fn generate_typed<T: Token>(
 						#buffer_ident::new(v)
 					},
 					quote! {
-						match ::std::string::String::from_utf8(v) {
+						match #lib_string::from_utf8(v) {
 							Ok(s) => #buffer_ident::new(s).map_err(|#error(s)| #error(s.into_bytes())),
 							Err(e) => Err(#error(e.into_bytes()))
 						}
@@ -1020,7 +1032,7 @@ fn generate_typed<T: Token>(
 				(
 					quote! {
 						#buffer_ident::new(v.into_bytes()).map_err(|#error(bytes)| unsafe {
-							#error(::std::string::String::from_utf8_unchecked(bytes))
+							#error(#lib_string::from_utf8_unchecked(bytes))
 						})
 					},
 					quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,10 +56,10 @@
 //! # use static_regular_grammar::RegularGrammar;
 //! /// Example grammar.
 //! #[derive(RegularGrammar)]
-//! #[grammar(file = "examples/test.abnf", entry_point = "bar")]
-//! pub struct Bar([u8]);
+//! #[grammar(file = "examples/test.abnf")]
+//! pub struct Foo([u8]);
 //!
-//! let bar = Bar::new(b"baaaar").unwrap();
+//! let foo = Foo::new(b"foo").unwrap();
 //! ```
 //!
 //! # ASCII
@@ -71,10 +71,10 @@
 //! # use static_regular_grammar::RegularGrammar;
 //! #[derive(RegularGrammar)]
 //! #[grammar(file = "examples/test.abnf", ascii)]
-//! pub struct Bar([u8]);
+//! pub struct Foo([u8]);
 //!
-//! let bar = Bar::new(b"baaaar").unwrap();
-//! println!("{bar}");
+//! let foo = Foo::new(b"foo").unwrap();
+//! println!("{foo}");
 //! ```
 //!
 //! # Sized Type

--- a/src/options.rs
+++ b/src/options.rs
@@ -62,7 +62,7 @@ fn build_cache_path(ident: &Ident, path: Option<PathBuf>) -> Result<PathBuf, (Er
 		None => {
 			let target =
 				find_target_dir().map_err(|e| (Error::TargetDirNotFound(e), ident.span()))?;
-			Ok(format!("{target}/regular-grammar/{}.automaton.cbor", ident).into())
+			Ok(format!("{target}/regular-grammar/{ident}.automaton.cbor").into())
 		}
 	}
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,7 +30,7 @@ impl fmt::Display for Sanitized<u8> {
 	}
 }
 
-impl<'a> fmt::Display for Sanitized<&'a str> {
+impl fmt::Display for Sanitized<&str> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		for c in self.0.chars() {
 			fmt_char_sanitized(c, f)?;
@@ -40,7 +40,7 @@ impl<'a> fmt::Display for Sanitized<&'a str> {
 	}
 }
 
-impl<'a> fmt::Display for Sanitized<&'a [u8]> {
+impl fmt::Display for Sanitized<&[u8]> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		for &c in self.0 {
 			fmt_u8_sanitized(c, f)?;
@@ -50,7 +50,7 @@ impl<'a> fmt::Display for Sanitized<&'a [u8]> {
 	}
 }
 
-impl<'a> fmt::Display for Sanitized<&'a String> {
+impl fmt::Display for Sanitized<&String> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		for c in self.0.chars() {
 			fmt_char_sanitized(c, f)?;
@@ -60,7 +60,7 @@ impl<'a> fmt::Display for Sanitized<&'a String> {
 	}
 }
 
-impl<'a> fmt::Display for Sanitized<&'a Vec<u8>> {
+impl fmt::Display for Sanitized<&Vec<u8>> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		for &c in self.0 {
 			fmt_u8_sanitized(c, f)?;
@@ -87,11 +87,11 @@ pub fn fmt_char_sanitized(c: char, f: &mut fmt::Formatter) -> fmt::Result {
 		c => {
 			let value = c as u32;
 			if value <= 0xff {
-				write!(f, "\\x{{{:02x}}}", value)
+				write!(f, "\\x{{{value:02x}}}")
 			} else if value <= 0xffff {
-				write!(f, "\\x{{{:04x}}}", value)
+				write!(f, "\\x{{{value:04x}}}")
 			} else {
-				write!(f, "\\x{{{:08x}}}", value)
+				write!(f, "\\x{{{value:08x}}}")
 			}
 		}
 	}
@@ -112,7 +112,7 @@ pub fn fmt_u8_sanitized(c: u8, f: &mut fmt::Formatter) -> fmt::Result {
 		0x1b => "\\e".fmt(f),
 		c if is_graphic_byte(c) => (c as char).fmt(f),
 		c => {
-			write!(f, "\\x{{{:02x}}}", c)
+			write!(f, "\\x{{{c:02x}}}")
 		}
 	}
 }

--- a/src/utils/automaton.rs
+++ b/src/utils/automaton.rs
@@ -298,7 +298,7 @@ impl<Q: Ord, L: Ord> DetAutomaton<Q, L> {
 	/// Minimizes the automaton.
 	// Hopcroft's algorithm.
 	// https://en.wikipedia.org/wiki/DFA_minimization
-	pub fn minimize<'a, P>(&'a self, partition: P) -> DetAutomaton<BTreeSet<&Q>, L>
+	pub fn minimize<'a, P>(&'a self, partition: P) -> DetAutomaton<BTreeSet<&'a Q>, L>
 	where
 		Q: Hash,
 		L: Default + Hash + MergeRef,


### PR DESCRIPTION
This PR should allow the crate to _build_ for `no_std` contexts when the standard library is not available, the crate still uses the standard library for code generation.
